### PR TITLE
Update scripts to run under CANVAS_USER

### DIFF
--- a/scripts/update-git.sh
+++ b/scripts/update-git.sh
@@ -54,6 +54,17 @@ else
     cd "$CANVAS_ROOT"
 fi
 
+# Create the folder with root and then chown it to CANVAS_USER
+if ! mkdir -p /opt/canvas-server; then
+    log_message "Error: Failed to create /opt/canvas-server directory"
+    exit 1
+fi
+
+if ! chown -R $CANVAS_USER:$CANVAS_GROUP /opt/canvas-server; then
+    log_message "Error: Failed to set permissions on /opt/canvas-server directory"
+    exit 1
+fi
+
 # Stop the PM2 service
 log_message "Stopping canvas-server service..."
 #pm2 stop canvas-server || log_message "Service was not running"
@@ -65,19 +76,19 @@ rm -rf node_modules
 
 # Pull latest changes
 log_message "Pulling latest changes from git..."
-if ! git fetch origin "$TARGET_BRANCH"; then
+if ! sudo -u "$CANVAS_USER" git fetch origin "$TARGET_BRANCH"; then
     log_message "Error: Failed to fetch latest changes from git."
     exit 1
 fi
 
-if ! git reset --hard "origin/$TARGET_BRANCH"; then
+if ! sudo -u "$CANVAS_USER" git reset --hard "origin/$TARGET_BRANCH"; then
     log_message "Error: Failed to reset to latest changes from git."
     exit 1
 fi
 
 # Install dependencies
 log_message "Installing dependencies..."
-if ! npm install; then
+if ! sudo -u "$CANVAS_USER" npm install; then
     log_message "Error: Failed to install dependencies."
     exit 1
 fi


### PR DESCRIPTION
Update `scripts/install-ubuntu.sh` and `scripts/update-git.sh` to run under the `CANVAS_USER` to avoid permission-related issues on subsequent git pull or fetch.

* **scripts/install-ubuntu.sh**
  - Add `sudo -u $CANVAS_USER` before commands that require user permissions.
  - Add a check to ensure `CANVAS_USER` can create a folder in `/opt`.
  - Create the folder with root and then chown it to `CANVAS_USER`.

* **scripts/update-git.sh**
  - Add `sudo -u $CANVAS_USER` before commands that require user permissions.
  - Create the folder with root and then chown it to `CANVAS_USER`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/canvas-ai/canvas-server/pull/71?shareId=fdca42e4-00d0-4a48-8d5b-57ba2aac7b31).