### PR TITLE
Enable chat streaming and update web ui submodule

### DIFF
--- a/src/api/websocket/channels/agent.js
+++ b/src/api/websocket/channels/agent.js
@@ -1,0 +1,147 @@
+'use strict';
+
+import { createDebug } from '../../../utils/log/index.js';
+
+const debug = createDebug('canvas-server:websocket:agent');
+
+/**
+ * Agent WebSocket channel for real-time agent interactions
+ * Handles streaming chat responses and agent status updates
+ * 
+ * @param {FastifyInstance} fastify - Fastify instance
+ * @param {Socket} socket - Socket.io socket instance
+ */
+export default function registerAgentWebSocket(fastify, socket) {
+  const { user } = socket;
+
+  debug(`🎭 Registering agent WebSocket for socket ${socket.id}, user ${user.email}`);
+
+  // Initialize subscriptions if not exists
+  if (!socket.subscriptions) {
+    socket.subscriptions = new Set();
+  }
+
+  // Handle agent subscriptions
+  socket.on('agent:subscribe', async (data) => {
+    try {
+      const { agentId } = data;
+      if (!agentId) {
+        socket.emit('error', { message: 'Agent ID required for subscription' });
+        return;
+      }
+
+      // Verify agent access
+      const agent = await fastify.agentManager.openAgent(user.id, agentId, user.id);
+      if (!agent) {
+        socket.emit('error', { message: 'Agent not found or access denied' });
+        return;
+      }
+
+      const subscriptionKey = `agent:${agentId}`;
+      socket.subscriptions.add(subscriptionKey);
+      socket.join(`agent:${agentId}`);
+
+      debug(`✅ Socket ${socket.id} subscribed to agent ${agentId}`);
+      socket.emit('agent:subscribed', { agentId });
+    } catch (error) {
+      debug(`❌ Agent subscription error for ${socket.id}: ${error.message}`);
+      socket.emit('error', { message: 'Failed to subscribe to agent' });
+    }
+  });
+
+  // Handle agent unsubscriptions
+  socket.on('agent:unsubscribe', (data) => {
+    try {
+      const { agentId } = data;
+      if (!agentId) return;
+
+      const subscriptionKey = `agent:${agentId}`;
+      socket.subscriptions.delete(subscriptionKey);
+      socket.leave(`agent:${agentId}`);
+
+      debug(`🔇 Socket ${socket.id} unsubscribed from agent ${agentId}`);
+      socket.emit('agent:unsubscribed', { agentId });
+    } catch (error) {
+      debug(`❌ Agent unsubscription error for ${socket.id}: ${error.message}`);
+    }
+  });
+
+  // Handle streaming chat requests
+  socket.on('agent:chat:stream', async (data) => {
+    try {
+      const { agentId, message, context, mcpContext = true, maxTokens, temperature } = data;
+      
+      if (!agentId || !message) {
+        socket.emit('agent:chat:error', { 
+          agentId, 
+          error: 'Agent ID and message are required' 
+        });
+        return;
+      }
+
+      // Verify agent access and status
+      const agent = await fastify.agentManager.openAgent(user.id, agentId, user.id);
+      if (!agent) {
+        socket.emit('agent:chat:error', { 
+          agentId, 
+          error: 'Agent not found or access denied' 
+        });
+        return;
+      }
+
+      if (!agent.isActive) {
+        socket.emit('agent:chat:error', { 
+          agentId, 
+          error: 'Agent is not active. Please start the agent first.' 
+        });
+        return;
+      }
+
+      // Start streaming response
+      socket.emit('agent:chat:start', { agentId, messageId: data.messageId });
+
+      const onChunk = (chunk) => {
+        socket.emit('agent:chat:chunk', {
+          agentId,
+          messageId: data.messageId,
+          type: chunk.type,
+          content: chunk.content,
+          delta: chunk.delta
+        });
+      };
+
+      // Execute streaming chat
+      const result = await agent.chatStream(message, {
+        context,
+        mcpContext,
+        maxTokens,
+        temperature,
+        onChunk
+      });
+
+      // Send completion
+      socket.emit('agent:chat:complete', {
+        agentId,
+        messageId: data.messageId,
+        result
+      });
+
+      debug(`💬 Streaming chat completed for agent ${agentId} by user ${user.id}`);
+    } catch (error) {
+      debug(`❌ Streaming chat error for ${socket.id}: ${error.message}`);
+      socket.emit('agent:chat:error', {
+        agentId: data?.agentId,
+        messageId: data?.messageId,
+        error: error.message || 'Failed to process chat stream'
+      });
+    }
+  });
+
+  // Clean up subscriptions on disconnect
+  socket.on('disconnect', () => {
+    debug(`🔌 Agent WebSocket cleanup for socket ${socket.id}`);
+    // Subscriptions are automatically cleaned up by socket.io
+  });
+
+  debug(`✅ Agent WebSocket registered for socket ${socket.id}`);
+}

--- a/src/api/websocket/index.js
+++ b/src/api/websocket/index.js
@@ -3,6 +3,7 @@
 import { createDebug } from '../../utils/log/index.js';
 import registerContextWebSocket from './channels/context.js';
 import registerWorkspaceWebSocket from './channels/workspace.js';
+import registerAgentWebSocket from './channels/agent.js';
 
 const debug = createDebug('canvas-server:websocket:main');
 
@@ -174,6 +175,8 @@ export default function setupWebSocketHandlers(fastify) {
     registerContextWebSocket(fastify, socket);
     debug(`📋 Registering workspace WebSocket for socket ${socket.id}`);
     registerWorkspaceWebSocket(fastify, socket);
+    debug(`📋 Registering agent WebSocket for socket ${socket.id}`);
+    registerAgentWebSocket(fastify, socket);
 
     socket.emit('authenticated', { userId: user.id, email: user.email });
     debug(`✅ Sent authentication confirmation to ${socket.id}`);

--- a/src/managers/agent/lib/connectors/BaseLLMConnector.js
+++ b/src/managers/agent/lib/connectors/BaseLLMConnector.js
@@ -29,6 +29,17 @@ class BaseLLMConnector {
     }
 
     /**
+     * Chat with the LLM using streaming
+     * @param {Array} messages - Array of message objects
+     * @param {Object} options - Chat options
+     * @param {Function} onChunk - Callback for each streaming chunk
+     * @returns {Promise<Object>} Final response object
+     */
+    async chatStream(messages, options = {}, onChunk = () => {}) {
+        throw new Error('chatStream() method must be implemented by subclass');
+    }
+
+    /**
      * Check if the connector is available
      * @returns {Promise<boolean>} Availability status
      */

--- a/src/managers/agent/lib/connectors/OllamaConnector.js
+++ b/src/managers/agent/lib/connectors/OllamaConnector.js
@@ -72,6 +72,30 @@ class OllamaConnector extends BaseLLMConnector {
     }
 
     /**
+     * Chat with streaming (fallback to regular chat for now)
+     * @param {Array} messages - Array of message objects
+     * @param {Object} options - Chat options
+     * @param {Function} onChunk - Callback for each streaming chunk
+     * @returns {Promise<Object>} Response object
+     */
+    async chatStream(messages, options = {}, onChunk = () => {}) {
+        // For now, fallback to regular chat and emit the full response as a single chunk
+        // TODO: Implement proper streaming when Ollama streaming API is integrated
+        const response = await this.chat(messages, options);
+        
+        // Emit the full content as a single chunk
+        if (response.content) {
+            onChunk({
+                type: 'content',
+                content: response.content,
+                delta: response.content
+            });
+        }
+        
+        return response;
+    }
+
+    /**
      * Chat using native Ollama API
      * @param {Array} messages - Array of message objects
      * @param {Object} options - Chat options


### PR DESCRIPTION
Implement streaming support for agent-based chats in the backend API.

This PR introduces WebSocket-based streaming for real-time agent responses, with a Server-Sent Events (SSE) fallback endpoint. It includes updates to LLM connectors (Anthropic, OpenAI, Ollama) and the Agent class to support streaming. A `TODO.web.md` file has been created to guide the necessary frontend changes in the `src/ui/web` submodule.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe5a158-e9cd-40bc-90e2-470513b99776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fe5a158-e9cd-40bc-90e2-470513b99776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>